### PR TITLE
Adds --only argument to specify which apps to only squash

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ script:
 - coverage run setup.py test
 - coverage report -m --fail-under=85
 - flake8
-- isort --check-only
+- isort --check .
 
 after_success:
 - codecov

--- a/django_squash/apps.py
+++ b/django_squash/apps.py
@@ -5,8 +5,8 @@ class DjangoSquashConfig(AppConfig):
     name = 'django_squash'
 
     def ready(self):
-        from .management.commands.lib.serializer import VariableSerializer
         from .management.commands.lib.operators import Variable
+        from .management.commands.lib.serializer import VariableSerializer
 
         try:
             from django.db.migrations.serializer import Serializer

--- a/django_squash/management/commands/squash_migrations.py
+++ b/django_squash/management/commands/squash_migrations.py
@@ -57,12 +57,16 @@ class Command(BaseCommand):
 
         ignore_apps = []
         bad_apps = []
-        for app_label in kwargs['ignore_app']:
-            try:
-                apps.get_app_config(app_label)
-                ignore_apps.append(app_label)
-            except (LookupError, TypeError):
-                bad_apps.append(str(app_label))
+
+
+        for app_labels in kwargs['ignore_app']:
+            for app_label in app_labels:
+                try:
+                    apps.get_app_config(app_label)
+                    ignore_apps.append(app_label)
+                except (LookupError, TypeError):
+                    bad_apps.append(str(app_label))
+
         if bad_apps:
             raise CommandError("The following apps are not valid: %s" % (', '.join(bad_apps)))
 

--- a/django_squash/management/commands/squash_migrations.py
+++ b/django_squash/management/commands/squash_migrations.py
@@ -7,6 +7,7 @@ from django.db.migrations.loader import MigrationLoader
 from django.db.migrations.state import ProjectState
 
 from django_squash import settings
+
 from .lib.autodetector import SquashMigrationAutodetector
 from .lib.loader import SquashMigrationLoader
 from .lib.questioner import NonInteractiveMigrationQuestioner

--- a/django_squash/management/commands/squash_migrations.py
+++ b/django_squash/management/commands/squash_migrations.py
@@ -35,6 +35,9 @@ except ImportError:
 class Command(BaseCommand):
     def add_arguments(self, parser):
         parser.add_argument(
+            '--only', action='append', nargs='*', help='Only squash the specified apps'
+        )
+        parser.add_argument(
             '--ignore-app',  action='append', nargs='*', default=settings.DJANGO_SQUASH_IGNORE_APPS,
             help='Ignore app name from quashing, ensure that there is nothing dependent on these apps. '
                  '(default: %(default)s)',
@@ -66,6 +69,21 @@ class Command(BaseCommand):
                     ignore_apps.append(app_label)
                 except (LookupError, TypeError):
                     bad_apps.append(str(app_label))
+
+        if kwargs['only']:
+            only_apps = []
+
+            for app_labels in kwargs['only']:
+                for app_label in app_labels:
+                    try:
+                        apps.get_app_config(app_label)
+                        only_apps.append(app_label)
+                    except (LookupError, TypeError):
+                        bad_apps.append(str(app_label))
+
+            for app_name in apps.app_configs.keys():
+                if not app_name in only_apps:
+                    ignore_apps.append(app_name)
 
         if bad_apps:
             raise CommandError("The following apps are not valid: %s" % (', '.join(bad_apps)))

--- a/django_squash/management/commands/squash_migrations.py
+++ b/django_squash/management/commands/squash_migrations.py
@@ -7,7 +7,6 @@ from django.db.migrations.loader import MigrationLoader
 from django.db.migrations.state import ProjectState
 
 from django_squash import settings
-
 from .lib.autodetector import SquashMigrationAutodetector
 from .lib.loader import SquashMigrationLoader
 from .lib.questioner import NonInteractiveMigrationQuestioner
@@ -61,7 +60,6 @@ class Command(BaseCommand):
         ignore_apps = []
         bad_apps = []
 
-
         for app_labels in kwargs['ignore_app']:
             for app_label in app_labels:
                 try:
@@ -82,7 +80,7 @@ class Command(BaseCommand):
                         bad_apps.append(str(app_label))
 
             for app_name in apps.app_configs.keys():
-                if not app_name in only_apps:
+                if app_name not in only_apps:
                     ignore_apps.append(app_name)
 
         if bad_apps:

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ class DjangoTest(TestCommand):
 
 setup(
     name='django_squash',
-    version='0.0.4',
+    version='0.0.5',
     description="A migration squasher that doesn't care how Humpty Dumpty was put together.",
     long_description=README,
     classifiers=[

--- a/tests/app/test_migrations.py
+++ b/tests/app/test_migrations.py
@@ -251,6 +251,19 @@ class SquashMigrationTest(MigrationTestBase):
                              no_color=True)
             self.assertEqual(set(squash_mock.call_args[1]['ignore_apps']), {'app2', 'app'})
 
+    def test_only_argument(self):
+        out = io.StringIO()
+        patch_app_migrations = self.temporary_migration_module(module="app.test_empty", app_label='app')
+
+        with unittest.mock.patch(
+         target="django_squash.management.commands.lib.autodetector.SquashMigrationAutodetector.squash",
+         autospec=True) as squash_mock, patch_app_migrations:
+            with self.assertRaisesMessage(CommandError, "There are no migrations to squash."):
+                call_command('squash_migrations', '--only', 'app2', 'app', verbosity=1, stdout=out,
+                             no_color=True)
+            self.assertEqual(set(squash_mock.call_args[1]['ignore_apps']),
+                             set(self.available_apps) - {'app', 'app2'})
+
     def test_simple_delete_squashing_migrations_noop(self):
         class Person(models.Model):
             name = models.CharField(max_length=10)

--- a/tests/app/test_migrations.py
+++ b/tests/app/test_migrations.py
@@ -236,7 +236,7 @@ class SquashMigrationTest(MigrationTestBase):
         patch_app_migrations = self.temporary_migration_module(module="app.test_empty", app_label='app')
         catch_error = self.assertRaisesMessage(CommandError, "The following apps are not valid: a, b")
         with patch_app_migrations, catch_error:
-            call_command('squash_migrations', verbosity=1, stdout=out, no_color=True, ignore_app=['a', 'b'])
+            call_command('squash_migrations', '--ignore-app', 'a', 'b', verbosity=1, stdout=out, no_color=True)
 
     def test_simple_delete_squashing_migrations_noop(self):
         class Person(models.Model):

--- a/tests/app/test_migrations.py
+++ b/tests/app/test_migrations.py
@@ -264,6 +264,18 @@ class SquashMigrationTest(MigrationTestBase):
             self.assertEqual(set(squash_mock.call_args[1]['ignore_apps']),
                              set(self.available_apps) - {'app', 'app2'})
 
+    def test_only_argument_with_invalid_apps(self):
+        out = io.StringIO()
+        patch_app_migrations = self.temporary_migration_module(module="app.test_empty", app_label='app')
+
+        with unittest.mock.patch(
+         target="django_squash.management.commands.lib.autodetector.SquashMigrationAutodetector.squash",
+         autospec=True) as squash_mock, patch_app_migrations:
+            with self.assertRaisesMessage(CommandError, "The following apps are not valid: invalid"):
+                call_command('squash_migrations', '--only', 'app2', 'invalid', verbosity=1, stdout=out,
+                             no_color=True)
+            self.assertFalse(squash_mock.called)
+
     def test_simple_delete_squashing_migrations_noop(self):
         class Person(models.Model):
             name = models.CharField(max_length=10)

--- a/tests/app/test_migrations.py
+++ b/tests/app/test_migrations.py
@@ -4,6 +4,7 @@ import io
 import os
 import shutil
 import tempfile
+import unittest.mock
 from contextlib import contextmanager
 from importlib import import_module
 
@@ -237,6 +238,18 @@ class SquashMigrationTest(MigrationTestBase):
         catch_error = self.assertRaisesMessage(CommandError, "The following apps are not valid: a, b")
         with patch_app_migrations, catch_error:
             call_command('squash_migrations', '--ignore-app', 'a', 'b', verbosity=1, stdout=out, no_color=True)
+
+    def test_ignore_apps_argument(self):
+        out = io.StringIO()
+        patch_app_migrations = self.temporary_migration_module(module="app.test_empty", app_label='app')
+
+        with unittest.mock.patch(
+         target="django_squash.management.commands.lib.autodetector.SquashMigrationAutodetector.squash",
+         autospec=True) as squash_mock, patch_app_migrations:
+            with self.assertRaisesMessage(CommandError, "There are no migrations to squash."):
+                call_command('squash_migrations', '--ignore-app', 'app2', 'app', verbosity=1, stdout=out,
+                             no_color=True)
+            self.assertEqual(set(squash_mock.call_args[1]['ignore_apps']), {'app2', 'app'})
 
     def test_simple_delete_squashing_migrations_noop(self):
         class Person(models.Model):


### PR DESCRIPTION
This merge request contains two things:

- a fix for the `--ignore-app` argument: It did not work correctly if multiple apps were specified
- a new `--only` argument: if specified, it only squashes the migrations for the specified apps