### PR TITLE
Adds latest (main) django to the list of versions to check

### DIFF
--- a/.github/workflows/_tests.yml
+++ b/.github/workflows/_tests.yml
@@ -24,9 +24,12 @@ jobs:
           - "4.1.*"
           - "4.2.*"
           - "5.0.*"
+          - "main"
         exclude:
           - { django-version: "5.0.*", python-version: "3.8" }
+          - { django-version: "main", python-version: "3.8" }
           - { django-version: "5.0.*", python-version: "3.9" }
+          - { django-version: "main", python-version: "3.9" }
     steps:
       - uses: actions/checkout@v4
         with:
@@ -35,7 +38,12 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install prerequisites
-        run: python -m pip install --upgrade pip setuptools codecov pip install codecov django==${{ matrix.django-version }}
+        run: |
+          DJANGO=django==${{ matrix.django-version }}
+          if [[ "$DJANGO" == "main" ]]; then
+            DJANGO="git+https://github.com/django/django.git@main"
+          fi
+          python -m pip install --upgrade pip setuptools codecov pip install codecov $DJANGO
       - name: Install packages
         run: pip install -e '.[test]'
       - name: Run tests

--- a/.github/workflows/_tests.yml
+++ b/.github/workflows/_tests.yml
@@ -39,8 +39,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install prerequisites
         run: |
-          DJANGO=${{ matrix.django-version }}
-          if [[ "$DJANGO" == "main" ]]; then
+          DJANGO="django==${{ matrix.django-version }}"
+          if [[ "${{ matrix.django-version }}" == "main" ]]; then
             DJANGO="git+https://github.com/django/django.git@main"
           fi
           python -m pip install --upgrade pip setuptools codecov pip install codecov $DJANGO

--- a/.github/workflows/_tests.yml
+++ b/.github/workflows/_tests.yml
@@ -39,7 +39,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install prerequisites
         run: |
-          DJANGO=django==${{ matrix.django-version }}
+          DJANGO=${{ matrix.django-version }}
           if [[ "$DJANGO" == "main" ]]; then
             DJANGO="git+https://github.com/django/django.git@main"
           fi


### PR DESCRIPTION
Now that we're doing nightly tests with the `.github/workflows/daily_tests.yml` workflow, we need to check the latest django and make sure nothing is going to break our utility.