### PR TITLE
Check python/django EOL and throw warnings

### DIFF
--- a/.github/workflows/_tests.yml
+++ b/.github/workflows/_tests.yml
@@ -23,9 +23,24 @@ jobs:
       - name: Generate matrix from setup.py
         id: set-matrix
         run: |
-          set -x
           python -c "from setup import GITHUB_MATRIX; print(GITHUB_MATRIX)" > matrix.json
           echo "matrix=$(<matrix.json)" >> $GITHUB_OUTPUT
+      - name: Check version EOF
+        run: |
+          set -x
+          python -c "import json
+          from urllib.request import Request, urlopen
+          from datetime import date, datetime
+          from itertools import chain, zip_longest
+          from setup import DJANGO_VERSIONS, PYTHON_VERSIONS
+          today = date.today()
+          versions = chain.from_iterable([zip_longest(['django'] * len(DJANGO_VERSIONS), DJANGO_VERSIONS), zip_longest(['python'] * len(PYTHON_VERSIONS), PYTHON_VERSIONS)])
+          for product, version in versions:
+              url = f'https://endoflife.date/api/{product}/{version}.json'
+              with urlopen(Request(url)) as httpresponse:
+                  eol = json.loads(httpresponse.read())['eol']
+                  if datetime.strptime(eol, '%Y-%m-%d').date() < today:
+                      print(f'::warning ::{product} v{version}: EOL was {eol}')"
 
   tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/_tests.yml
+++ b/.github/workflows/_tests.yml
@@ -42,7 +42,7 @@ jobs:
                   eol = json.loads(httpresponse.read())['eol']
                   eol_date = datetime.strptime(eol, '%Y-%m-%d').date()
                   if eol_date < today:
-                      print(f'::error ::{product} v{version}: EOL was {eol}')"
+                      print(f'::error ::{product} v{version}: EOL was {eol}')
                   elif eol_date - today < WARNING_DAYS:
                       print(f'::warning ::{product} v{version}: EOL is coming up on the {eol}')"
 

--- a/.github/workflows/_tests.yml
+++ b/.github/workflows/_tests.yml
@@ -40,7 +40,7 @@ jobs:
               with urlopen(Request(url)) as httpresponse:
                   eol = json.loads(httpresponse.read())['eol']
                   if datetime.strptime(eol, '%Y-%m-%d').date() < today:
-                      print(f'::warning ::{product} v{version}: EOL was {eol}')"
+                      print(f'::error ::{product} v{version}: EOL was {eol}')"
 
   tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/_tests.yml
+++ b/.github/workflows/_tests.yml
@@ -30,17 +30,21 @@ jobs:
           set -x
           python -c "import json
           from urllib.request import Request, urlopen
-          from datetime import date, datetime
+          from datetime import date, datetime, timedelta
           from itertools import chain, zip_longest
           from setup import DJANGO_VERSIONS, PYTHON_VERSIONS
           today = date.today()
+          WARNING_DAYS = timedelta(days=90)
           versions = chain.from_iterable([zip_longest(['django'] * len(DJANGO_VERSIONS), DJANGO_VERSIONS), zip_longest(['python'] * len(PYTHON_VERSIONS), PYTHON_VERSIONS)])
           for product, version in versions:
               url = f'https://endoflife.date/api/{product}/{version}.json'
               with urlopen(Request(url)) as httpresponse:
                   eol = json.loads(httpresponse.read())['eol']
-                  if datetime.strptime(eol, '%Y-%m-%d').date() < today:
+                  eol_date = datetime.strptime(eol, '%Y-%m-%d').date()
+                  if eol_date < today:
                       print(f'::error ::{product} v{version}: EOL was {eol}')"
+                  elif eol_date - today < WARNING_DAYS:
+                      print(f'::warning ::{product} v{version}: EOL is coming up on the {eol}')"
 
   tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Doesn't exactly throw warnings/errors, but it does show them in the summary of the "runs", a little hidden. But its ok for now.