### PR TITLE
Unify coverage files

### DIFF
--- a/.github/workflows/_tests.yml
+++ b/.github/workflows/_tests.yml
@@ -123,7 +123,11 @@ jobs:
     if: success() || failure()
     steps:
       - uses: actions/checkout@v4
-
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.12
+      - name: Install coverage
+        run: pip install coverage
       - name: Download reports' artifacts
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/_tests.yml
+++ b/.github/workflows/_tests.yml
@@ -7,6 +7,9 @@ on:
         required: true
         type: string
 
+env:
+  DEFAULT_PYTHON_VERSION: 3.12
+
 jobs:
   prepare-matrix:
     name: Prepare Python/Django matrix
@@ -20,7 +23,7 @@ jobs:
           ref: ${{ inputs.ref }}
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.12
+          python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
       - name: Install the linters
         run: |
           pip install --upgrade setuptools
@@ -123,7 +126,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.12
+          python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
       - name: Install coverage
         run: pip install coverage
       - name: Download artifacts

--- a/.github/workflows/_tests.yml
+++ b/.github/workflows/_tests.yml
@@ -148,19 +148,10 @@ jobs:
           path: .coverage
           retention-days: 1
 
-      # - name: Place reports' artifacts
-      #   run: rsync -av downloaded_artifacts/*/*/ unit_test_reports/
-      # - name: Check reports existence
-      #   id: check_files
-      #   uses: andstor/file-existence-action@v1
-      #   with:
-      #     files: 'unit_test_reports/**/test-*.xml'
-      # - name: Import results to Xray
-      #   run: ls -R unit_test_reports/
-
-      # - name: Upload coverage to Codecov
-      #   uses: codecov/codecov-action@v4
-      #   with:
-      #     fail_ci_if_error: true
-      #     token: ${{ secrets.CODECOV_TOKEN }}
-      #     env_vars: OS,RUST
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        continue-on-error: true
+        with:
+          fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}
+          env_vars: OS,RUST

--- a/.github/workflows/_tests.yml
+++ b/.github/workflows/_tests.yml
@@ -98,6 +98,7 @@ jobs:
           key: ${{ runner.os }}-py-${{ matrix.python-version }}-dj-${{ matrix.django-version }}
       - name: Install prerequisites
         run: |
+          echo ARTIFACT_NAME=artifact_${{ runner.os }}-py-${{ matrix.python-version }}-dj-${{ matrix.django-version }} | sed 's|\.\*||g' >> "$GITHUB_ENV"
           DJANGO="django==${{ matrix.django-version }}"
           if [[ "${{ matrix.django-version }}" == "main" ]]; then
             DJANGO="git+https://github.com/django/django.git@main"
@@ -115,7 +116,7 @@ jobs:
         if: success() || failure()
         uses: actions/upload-artifact@v4
         with:
-          name: artifact_${{ runner.os }}-py-${{ matrix.python-version }}-dj-${{ matrix.django-version }}
+          name: ${{ env.ARTIFACT_NAME }}
           if-no-files-found: ignore
           path: .coverage
           retention-days: 1

--- a/.github/workflows/_tests.yml
+++ b/.github/workflows/_tests.yml
@@ -110,7 +110,7 @@ jobs:
       - name: Install packages
         run: pip install -e '.[test]'
       - name: Run tests
-        run: pytest --cov django_squash --cov-report=term -m 'not slow'
+        run: pytest --cov django_squash --cov-report=term
       - name: Upload coverage artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/_tests.yml
+++ b/.github/workflows/_tests.yml
@@ -115,7 +115,7 @@ jobs:
         if: success() || failure()
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ env.RUN_UNIQUE_ID }}_artifact_${{ matrix.step }}
+          name: artifact_${{ runner.os }}-py-${{ matrix.python-version }}-dj-${{ matrix.django-version }}
           if-no-files-found: ignore
           path: .coverage
           retention-days: 1

--- a/.github/workflows/_tests.yml
+++ b/.github/workflows/_tests.yml
@@ -98,7 +98,7 @@ jobs:
           key: ${{ runner.os }}-py-${{ matrix.python-version }}-dj-${{ matrix.django-version }}
       - name: Install prerequisites
         run: |
-          echo ARTIFACT_NAME=artifact_${{ runner.os }}-py-${{ matrix.python-version }}-dj-${{ matrix.django-version }} | sed 's|\.\*||g' >> "$GITHUB_ENV"
+          echo ARTIFACT_NAME=coverage_${{ runner.os }}-py-${{ matrix.python-version }}-dj-${{ matrix.django-version }} | sed 's|\.\*||g' >> "$GITHUB_ENV"
           DJANGO="django==${{ matrix.django-version }}"
           if [[ "${{ matrix.django-version }}" == "main" ]]; then
             DJANGO="git+https://github.com/django/django.git@main"
@@ -129,8 +129,12 @@ jobs:
         with:
           path: downloaded_artifacts
       - uses: geekyeggo/delete-artifact@v5
+        with:
+            name: coverage_*
       - name: what we got
-        run: find .
+        run: |
+          coverage combine downloaded_artifacts/
+          find .
 
       # - name: Place reports' artifacts
       #   run: rsync -av downloaded_artifacts/*/*/ unit_test_reports/

--- a/.github/workflows/_tests.yml
+++ b/.github/workflows/_tests.yml
@@ -105,8 +105,45 @@ jobs:
           python -m pip install --upgrade pip setuptools codecov pip install codecov $DJANGO
       - name: Install packages
         run: pip install -e '.[test]'
+      - name: before tests
+        run: ls -lash
       - name: Run tests
         run: pytest --cov django_squash --cov-report=xml --cov-report=term
+      - name: after tests
+        run: ls -lash
+      - name: Upload coverage artifacts
+        if: success() || failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.RUN_UNIQUE_ID }}_artifact_${{ matrix.step }}
+          if-no-files-found: ignore
+          path: coverage
+          retention-days: 1
+
+  coverage:
+    runs-on: ubuntu-latest
+    needs: tests
+    if: success() || failure()
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download reports' artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: downloaded_artifacts
+      - name: what we got
+        run: find .
+
+      # - name: Place reports' artifacts
+      #   run: rsync -av downloaded_artifacts/*/*/ unit_test_reports/
+      # - name: Check reports existence
+      #   id: check_files
+      #   uses: andstor/file-existence-action@v1
+      #   with:
+      #     files: 'unit_test_reports/**/test-*.xml'
+      # - name: Import results to Xray
+      #   run: ls -R unit_test_reports/
+
       # - name: Upload coverage to Codecov
       #   uses: codecov/codecov-action@v4
       #   with:

--- a/.github/workflows/_tests.yml
+++ b/.github/workflows/_tests.yml
@@ -108,12 +108,10 @@ jobs:
         run: pip install -e '.[test]'
       - name: Run tests
         run: pytest --cov django_squash --cov-report=term -m 'not slow'
-      - name: Upload coverage artifacts
-        if: success() || failure()
+      - name: Upload coverage artifact
         uses: actions/upload-artifact@v4
         with:
           name: ${{ env.ARTIFACT_NAME }}
-          if-no-files-found: ignore
           path: .coverage
           retention-days: 1
 
@@ -136,10 +134,16 @@ jobs:
         uses: geekyeggo/delete-artifact@v5
         with:
             name: coverage_*
-      - name: what we got
+      - name: Combine coverage.py
         run: |
           coverage combine $(find downloaded_artifacts/ -type f | xargs)
-          find .
+          coverage xml
+      - name: Upload single coverage artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: .coverage
+          path: .coverage
+          retention-days: 1
 
       # - name: Place reports' artifacts
       #   run: rsync -av downloaded_artifacts/*/*/ unit_test_reports/

--- a/.github/workflows/_tests.yml
+++ b/.github/workflows/_tests.yml
@@ -106,12 +106,8 @@ jobs:
           python -m pip install --upgrade pip setuptools codecov pip install codecov $DJANGO
       - name: Install packages
         run: pip install -e '.[test]'
-      - name: before tests
-        run: ls -lash
       - name: Run tests
         run: pytest --cov django_squash --cov-report=term -m 'not slow'
-      - name: after tests
-        run: ls -lash
       - name: Upload coverage artifacts
         if: success() || failure()
         uses: actions/upload-artifact@v4
@@ -132,6 +128,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: downloaded_artifacts
+      - uses: geekyeggo/delete-artifact@v5
       - name: what we got
         run: find .
 

--- a/.github/workflows/_tests.yml
+++ b/.github/workflows/_tests.yml
@@ -138,7 +138,7 @@ jobs:
             name: coverage_*
       - name: what we got
         run: |
-          coverage combine $(find downloaded_artifacts/ type f | xargs)
+          coverage combine $(find downloaded_artifacts/ -type f | xargs)
           find .
 
       # - name: Place reports' artifacts

--- a/.github/workflows/_tests.yml
+++ b/.github/workflows/_tests.yml
@@ -108,7 +108,7 @@ jobs:
       - name: before tests
         run: ls -lash
       - name: Run tests
-        run: pytest --cov django_squash --cov-report=xml --cov-report=term -m 'not slow'
+        run: pytest --cov django_squash --cov-report=term -m 'not slow'
       - name: after tests
         run: ls -lash
       - name: Upload coverage artifacts
@@ -117,7 +117,7 @@ jobs:
         with:
           name: ${{ env.RUN_UNIQUE_ID }}_artifact_${{ matrix.step }}
           if-no-files-found: ignore
-          path: coverage
+          path: .coverage
           retention-days: 1
 
   coverage:

--- a/.github/workflows/_tests.yml
+++ b/.github/workflows/_tests.yml
@@ -128,16 +128,17 @@ jobs:
           python-version: 3.12
       - name: Install coverage
         run: pip install coverage
-      - name: Download reports' artifacts
+      - name: Download artifacts
         uses: actions/download-artifact@v4
         with:
           path: downloaded_artifacts
-      - uses: geekyeggo/delete-artifact@v5
+      - name: Clean up temporary artifacts
+        uses: geekyeggo/delete-artifact@v5
         with:
             name: coverage_*
       - name: what we got
         run: |
-          coverage combine downloaded_artifacts/
+          coverage combine $(find downloaded_artifacts/ type f | xargs)
           find .
 
       # - name: Place reports' artifacts

--- a/.github/workflows/_tests.yml
+++ b/.github/workflows/_tests.yml
@@ -108,7 +108,7 @@ jobs:
       - name: before tests
         run: ls -lash
       - name: Run tests
-        run: pytest --cov django_squash --cov-report=xml --cov-report=term
+        run: pytest --cov django_squash --cov-report=xml --cov-report=term -m 'not slow'
       - name: after tests
         run: ls -lash
       - name: Upload coverage artifacts


### PR DESCRIPTION
Code coverage was disabled a week ago because it was tripping about it going over the limit of uploads. Each of the tests was sending their own tests, 22 tests, 22 uploads, this was an issue. The idea here is to combine all the tests and do a single upload as opposed to 22 of them, hopefully this will make it harder to go over the limit.