### PR TITLE
Fixes bug/feature in GitHub action upload-artifact that ignores any file that starts with a dot.

### DIFF
--- a/.github/workflows/_tests.yml
+++ b/.github/workflows/_tests.yml
@@ -186,6 +186,7 @@ jobs:
           name: coverage_*
       - name: Combine coverage.py
         run: |
+          ls -ls downloaded_artifacts
           coverage combine $(find downloaded_artifacts/ -type f | xargs)
           coverage xml
       - name: Upload single coverage artifact

--- a/.github/workflows/_tests.yml
+++ b/.github/workflows/_tests.yml
@@ -157,12 +157,14 @@ jobs:
       - name: Install packages
         run: pip install -e '.[test]'
       - name: Run tests
-        run: pytest --cov django_squash --cov-report=term --cov-report=annotate:.coverage
+        run: pytest --cov django_squash --cov-report=term
+      - name: temp
+        run: pwd; ls -lsash
       - name: Upload coverage artifact
         uses: actions/upload-artifact@v4
         with:
           name: ${{ env.ARTIFACT_NAME }}
-          path: .coverage
+          path: ./.coverage
           retention-days: 1
 
   coverage:

--- a/.github/workflows/_tests.yml
+++ b/.github/workflows/_tests.yml
@@ -157,7 +157,10 @@ jobs:
       - name: Install packages
         run: pip install -e '.[test]'
       - name: Run tests
-        run: pytest --cov django_squash --cov-report=term --cov-report=annotate:dotcoverage
+        run: |
+          pytest --cov django_squash --cov-report=term
+          # There is an issue with "upload-artifact" that does not like files that start with a dot.
+          cp .coverage dotcoverage
       - name: temp
         run: pwd; ls -lsash
       - name: Upload coverage artifact

--- a/.github/workflows/_tests.yml
+++ b/.github/workflows/_tests.yml
@@ -161,8 +161,6 @@ jobs:
           pytest --cov django_squash --cov-report=term
           # There is an issue with "upload-artifact" that does not like files that start with a dot.
           cp .coverage dotcoverage
-      - name: temp
-        run: pwd; ls -lsash
       - name: Upload coverage artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/_tests.yml
+++ b/.github/workflows/_tests.yml
@@ -189,7 +189,6 @@ jobs:
           name: coverage_*
       - name: Combine coverage.py
         run: |
-          ls -ls downloaded_artifacts
           coverage combine $(find downloaded_artifacts/ -type f | xargs)
           coverage xml
       - name: Upload single coverage artifact

--- a/.github/workflows/_tests.yml
+++ b/.github/workflows/_tests.yml
@@ -157,14 +157,14 @@ jobs:
       - name: Install packages
         run: pip install -e '.[test]'
       - name: Run tests
-        run: pytest --cov django_squash --cov-report=term
+        run: pytest --cov django_squash --cov-report=term --cov-report=annotate:dotcoverage
       - name: temp
         run: pwd; ls -lsash
       - name: Upload coverage artifact
         uses: actions/upload-artifact@v4
         with:
           name: ${{ env.ARTIFACT_NAME }}
-          path: ./.coverage
+          path: dotcoverage
           retention-days: 1
 
   coverage:

--- a/.github/workflows/_tests.yml
+++ b/.github/workflows/_tests.yml
@@ -157,7 +157,7 @@ jobs:
       - name: Install packages
         run: pip install -e '.[test]'
       - name: Run tests
-        run: pytest --cov django_squash --cov-report=term
+        run: pytest --cov django_squash --cov-report=term --cov-report=.coverage
       - name: Upload coverage artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/_tests.yml
+++ b/.github/workflows/_tests.yml
@@ -190,12 +190,15 @@ jobs:
       - name: Combine coverage.py
         run: |
           coverage combine $(find downloaded_artifacts/ -type f | xargs)
+          # Used by codecov
           coverage xml
+          # There is an issue with "upload-artifact" that does not like files that start with a dot.
+          cp .coverage dotcoverage
       - name: Upload single coverage artifact
         uses: actions/upload-artifact@v4
         with:
           name: .coverage
-          path: .coverage
+          path: dotcoverage
           retention-days: 1
 
       - name: Upload coverage to Codecov

--- a/.github/workflows/_tests.yml
+++ b/.github/workflows/_tests.yml
@@ -157,7 +157,7 @@ jobs:
       - name: Install packages
         run: pip install -e '.[test]'
       - name: Run tests
-        run: pytest --cov django_squash --cov-report=term --cov-report=.coverage
+        run: pytest --cov django_squash --cov-report=term --cov-report=
       - name: Upload coverage artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/_tests.yml
+++ b/.github/workflows/_tests.yml
@@ -157,15 +157,13 @@ jobs:
       - name: Install packages
         run: pip install -e '.[test]'
       - name: Run tests
-        run: |
-          pytest --cov django_squash --cov-report=term
-          # There is an issue with "upload-artifact" that does not like files that start with a dot.
-          cp .coverage dotcoverage
+        run: pytest --cov django_squash --cov-report=term
       - name: Upload coverage artifact
         uses: actions/upload-artifact@v4
         with:
+          include-hidden-files: true
           name: ${{ env.ARTIFACT_NAME }}
-          path: dotcoverage
+          path: .coverage
           retention-days: 1
 
   coverage:
@@ -192,13 +190,12 @@ jobs:
           coverage combine $(find downloaded_artifacts/ -type f | xargs)
           # Used by codecov
           coverage xml
-          # There is an issue with "upload-artifact" that does not like files that start with a dot.
-          cp .coverage dotcoverage
       - name: Upload single coverage artifact
         uses: actions/upload-artifact@v4
         with:
+          include-hidden-files: true
           name: .coverage
-          path: dotcoverage
+          path: .coverage
           retention-days: 1
 
       - name: Upload coverage to Codecov

--- a/.github/workflows/_tests.yml
+++ b/.github/workflows/_tests.yml
@@ -157,7 +157,7 @@ jobs:
       - name: Install packages
         run: pip install -e '.[test]'
       - name: Run tests
-        run: pytest --cov django_squash --cov-report=term --cov-report=
+        run: pytest --cov django_squash --cov-report=term --cov-report=annotate:.coverage
       - name: Upload coverage artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/_tests.yml
+++ b/.github/workflows/_tests.yml
@@ -162,6 +162,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           include-hidden-files: true
+          if-no-files-found: error
           name: ${{ env.ARTIFACT_NAME }}
           path: .coverage
           retention-days: 1
@@ -194,6 +195,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           include-hidden-files: true
+          if-no-files-found: error
           name: .coverage
           path: .coverage
           retention-days: 1


### PR DESCRIPTION
This issue started about a week ago, been getting daily emails that the daily test had failed. Took me a good bit to find out where was the issue... Hell of a bug...

Thanks to this [issue](https://github.com/actions/upload-artifact/issues/618) for helping me identify the problem.