### PR TITLE
dev: Removes python 3.8 support

### DIFF
--- a/.github/workflows/_tests.yml
+++ b/.github/workflows/_tests.yml
@@ -39,7 +39,7 @@ jobs:
 
           DJANGO_VERSIONS = []
           PYTHON_VERSIONS = []
-          EXCLUDE_MATRIX = {"3.8": ["5.0.*", "5.1.*", "5.2.*", "main"], "3.9": ["5.0.*", "5.1.*", "5.2.*", "main"], "3.10": ["5.2.*", "main"], "3.11": ["5.2.*", "main"]}
+          EXCLUDE_MATRIX = {"3.9": ["5.0.*", "5.1.*", "5.2.*", "main"], "3.10": ["5.2.*", "main"], "3.11": ["5.2.*", "main"]}
 
           def is_number(s):
               try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ classifiers = [
     "Framework :: Django :: 5.2",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ classifiers = [
 dependencies = [
     "django>=4.2",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 
 [project.optional-dependencies]
 lint = [
@@ -69,7 +69,7 @@ platforms = ["any"]
 [tool.ruff]
 exclude = ["*migrations*", ".*", "/usr/local/lib", "dist", "venv"]
 line-length = 119
-target-version = "py38"
+target-version = "py39"
 
 [tool.ruff.lint]
 select = ["ALL"]


### PR DESCRIPTION
* Python 3.8 has been out of support since 2024-10-07
* [CI warning started today](https://github.com/kingbuzzman/django-squash/actions/runs/14607553404/job/40979492945) -- instead of patching it, removing py3.8
  * `DeprecationWarning: mypy_extensions.TypedDict is deprecated, and will be removed in a future version. Use typing.TypedDict or typing_extensions.TypedDict instead.`