### PR TITLE
Adds vulture

### DIFF
--- a/.github/workflows/_tests.yml
+++ b/.github/workflows/_tests.yml
@@ -114,6 +114,10 @@ jobs:
         run: |
           ruff check --extend-select I .
           ruff format --check .
+      - name: Vulture check
+        if: always()
+        run: |
+          vulture
       - name: rst check
         if: always()
         run: rst-lint .

--- a/django_squash/db/migrations/utils.py
+++ b/django_squash/db/migrations/utils.py
@@ -59,7 +59,7 @@ class UniqueVariableName:
         self.names = defaultdict(int)
         self.functions = {}
         self.context = context
-        self.naming_function = naming_function or (lambda n, c: n)
+        self.naming_function = naming_function or (lambda n, _: n)
 
     def update_context(self, context):
         self.context.update(context)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,8 @@ requires-python = ">=3.9"
 lint = [
     "pygments",
     "restructuredtext-lint",
-    "ruff"
+    "ruff",
+    "vulture"
 ]
 test = [
     "black",
@@ -184,6 +185,13 @@ fail_under = 95
 [tool.pypi]
 repository = "https://upload.pypi.org/legacy/"
 username = "kingbuzzman"
+
+[tool.vulture]
+make_whitelist = false
+min_confidence = 80
+paths = ["django_squash"]
+sort_by_size = true
+verbose = false
 
 [tool.pytest.ini_options]
 DJANGO_SETTINGS_MODULE = "settings"


### PR DESCRIPTION
While working on the `diff-cover` [PR](https://github.com/kingbuzzman/django-squash/pull/75), it came to my attention that a block like:

```
if False:
    ....
```

will never be told by coverage that it is missing, as it is seen it as "unreachable code" by the compiler, and coverage never sees it.