### PR TITLE
Fixes pytest --help from crashing

### DIFF
--- a/django_squash/db/migrations/utils.py
+++ b/django_squash/db/migrations/utils.py
@@ -25,6 +25,7 @@ def get_custom_rename_function():
 
     if custom_rename_function:
         return import_string(custom_rename_function)
+    return lambda n, _: n
 
 
 def file_hash(file_path):
@@ -55,11 +56,11 @@ class UniqueVariableName:
     This class will return a unique name for a variable / function.
     """
 
-    def __init__(self, context, naming_function=None):
+    def __init__(self, context, naming_function):
         self.names = defaultdict(int)
         self.functions = {}
         self.context = context
-        self.naming_function = naming_function or (lambda n, _: n)
+        self.naming_function = naming_function
 
     def update_context(self, context):
         self.context.update(context)

--- a/django_squash/management/commands/squash_migrations.py
+++ b/django_squash/management/commands/squash_migrations.py
@@ -20,7 +20,7 @@ class Command(BaseCommand):
         parser.add_argument(
             "--ignore-app",
             nargs="*",
-            default=app_settings.DJANGO_SQUASH_IGNORE_APPS,
+            default=list(app_settings.DJANGO_SQUASH_IGNORE_APPS),
             help="Ignore app name from quashing, ensure that there is nothing dependent on these apps. "
             "(default: %(default)s)",
         )
@@ -32,7 +32,7 @@ class Command(BaseCommand):
         )
         parser.add_argument(
             "--squashed-name",
-            default=app_settings.DJANGO_SQUASH_MIGRATION_NAME,
+            default=str(app_settings.DJANGO_SQUASH_MIGRATION_NAME),
             help="Sets the name of the new squashed migration. Also accepted are the standard datetime parse "
             'variables such as "%%Y%%m%%d". (default: "%(default)s" -> "xxxx_%(default)s")',
         )

--- a/django_squash/settings.py
+++ b/django_squash/settings.py
@@ -3,9 +3,7 @@ from __future__ import annotations
 from django.conf import settings as global_settings
 from django.utils.functional import lazy
 
-DJANGO_SQUASH_IGNORE_APPS = lazy(
-    lambda: getattr(global_settings, "DJANGO_SQUASH_IGNORE_APPS", None) or [], list
-)()
+DJANGO_SQUASH_IGNORE_APPS = lazy(lambda: getattr(global_settings, "DJANGO_SQUASH_IGNORE_APPS", None) or [], list)()
 DJANGO_SQUASH_MIGRATION_NAME = lazy(
     lambda: getattr(global_settings, "DJANGO_SQUASH_MIGRATION_NAME", None) or "squashed", str
 )()

--- a/django_squash/settings.py
+++ b/django_squash/settings.py
@@ -1,7 +1,14 @@
 from __future__ import annotations
 
 from django.conf import settings as global_settings
+from django.utils.functional import lazy
 
-DJANGO_SQUASH_IGNORE_APPS = getattr(global_settings, "DJANGO_SQUASH_IGNORE_APPS", None) or []
-DJANGO_SQUASH_MIGRATION_NAME = getattr(global_settings, "DJANGO_SQUASH_MIGRATION_NAME", None) or "squashed"
-DJANGO_SQUASH_CUSTOM_RENAME_FUNCTION = getattr(global_settings, "DJANGO_SQUASH_CUSTOM_RENAME_FUNCTION", None)
+DJANGO_SQUASH_IGNORE_APPS = lazy(
+    lambda: getattr(global_settings, "DJANGO_SQUASH_IGNORE_APPS", None) or [], list
+)()
+DJANGO_SQUASH_MIGRATION_NAME = lazy(
+    lambda: getattr(global_settings, "DJANGO_SQUASH_MIGRATION_NAME", None) or "squashed", str
+)()
+DJANGO_SQUASH_CUSTOM_RENAME_FUNCTION = lazy(
+    lambda: getattr(global_settings, "DJANGO_SQUASH_CUSTOM_RENAME_FUNCTION", None) or "", str
+)()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -68,14 +68,14 @@ def test_is_code_in_site_packages():
 
 
 def test_unique_names():
-    names = utils.UniqueVariableName({})
+    names = utils.UniqueVariableName({}, lambda n, _: n)
     assert names("var") == "var"
     assert names("var") == "var_2"
     assert names("var_2") == "var_2_2"
 
 
 def test_unique_function_names_errors():
-    names = utils.UniqueVariableName({})
+    names = utils.UniqueVariableName({}, lambda n, _: n)
 
     with pytest.raises(ValueError):
         names.function("not-a-function")
@@ -118,8 +118,8 @@ def test_unique_function_names_context():
 
 
 def test_unique_function_names():
-    uniq1 = utils.UniqueVariableName({})
-    uniq2 = utils.UniqueVariableName({})
+    uniq1 = utils.UniqueVariableName({}, lambda n, _: n)
+    uniq2 = utils.UniqueVariableName({}, lambda n, _: n)
 
     reassigned_func2 = func2
     reassigned_func2_impostor = func2_impostor
@@ -175,11 +175,11 @@ def test_normalize_function_name():
 
 def test_get_custom_rename_function(monkeypatch):
     """Cover all cases where DJANGO_SQUASH_CUSTOM_RENAME_FUNCTION can go wrong"""
-    assert not utils.get_custom_rename_function()
+    assert callable(utils.get_custom_rename_function())
     utils.get_custom_rename_function.cache_clear()
 
     monkeypatch.setattr("django_squash.settings.DJANGO_SQUASH_CUSTOM_RENAME_FUNCTION", "")
-    assert not utils.get_custom_rename_function()
+    assert callable(utils.get_custom_rename_function())
     utils.get_custom_rename_function.cache_clear()
 
     monkeypatch.setattr("django_squash.settings.DJANGO_SQUASH_CUSTOM_RENAME_FUNCTION", "tests.test_utils.func2")


### PR DESCRIPTION
Issue is that we're calling `utils.py` -> `settings.py` -> django's settings, but django hasn't loaded yet, so it crashes.
```
root@92650ac53ca7:/app# python -m pytest --help
Traceback (most recent call last):
  File "/usr/local/lib/python3.12/site-packages/_pytest/config/__init__.py", line 712, in _importconftest
    mod = import_path(
          ^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/_pytest/pathlib.py", line 587, in import_path
    importlib.import_module(module_name)
  File "/usr/local/lib/python3.12/importlib/__init__.py", line 90, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1387, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
  File "/usr/local/lib/python3.12/site-packages/_pytest/assertion/rewrite.py", line 186, in exec_module
    exec(co, module.__dict__)
  File "/app/tests/conftest.py", line 18, in <module>
    from django_squash.db.migrations.utils import get_custom_rename_function
  File "/app/django_squash/db/migrations/utils.py", line 16, in <module>
    from django_squash import settings as app_settings
  File "/app/django_squash/settings.py", line 5, in <module>
    DJANGO_SQUASH_IGNORE_APPS = getattr(global_settings, "DJANGO_SQUASH_IGNORE_APPS", None) or []
                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/django/conf/__init__.py", line 81, in __getattr__
    self._setup(name)
  File "/usr/local/lib/python3.12/site-packages/django/conf/__init__.py", line 61, in _setup
    raise ImproperlyConfigured(
django.core.exceptions.ImproperlyConfigured: Requested setting DJANGO_SQUASH_IGNORE_APPS, but settings are not configured. You must either define the environment variable DJANGO_SETTINGS_MODULE or call settings.configure() before accessing settings.
```

Fix:
* Make all the settings lazy