### PR TITLE
Standardize on BigAutoField causing issues with the new main branch

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,8 +6,6 @@ concurrency:
 
 on:
   pull_request:
-    branches:
-      - "**"
 
 permissions:
   contents: read

--- a/tests/app/tests/migrations/dangling_leaf/0001_initial.py
+++ b/tests/app/tests/migrations/dangling_leaf/0001_initial.py
@@ -15,7 +15,7 @@ class Migration(migrations.Migration):
             fields=[
                 (
                     "id",
-                    models.AutoField(
+                    models.BigAutoField(
                         auto_created=True,
                         primary_key=True,
                         serialize=False,

--- a/tests/app/tests/migrations/dangling_leaf/0003_squashed.py
+++ b/tests/app/tests/migrations/dangling_leaf/0003_squashed.py
@@ -15,7 +15,7 @@ class Migration(migrations.Migration):
             fields=[
                 (
                     "id",
-                    models.AutoField(
+                    models.BigAutoField(
                         auto_created=True,
                         primary_key=True,
                         serialize=False,

--- a/tests/app/tests/migrations/delete_replaced/0001_initial.py
+++ b/tests/app/tests/migrations/delete_replaced/0001_initial.py
@@ -15,7 +15,7 @@ class Migration(migrations.Migration):
             fields=[
                 (
                     "id",
-                    models.AutoField(
+                    models.BigAutoField(
                         auto_created=True,
                         primary_key=True,
                         serialize=False,

--- a/tests/app/tests/migrations/delete_replaced/0004_squashed.py
+++ b/tests/app/tests/migrations/delete_replaced/0004_squashed.py
@@ -25,7 +25,7 @@ class Migration(migrations.Migration):
             fields=[
                 (
                     "id",
-                    models.AutoField(
+                    models.BigAutoField(
                         auto_created=True,
                         primary_key=True,
                         serialize=False,

--- a/tests/app/tests/migrations/elidable/0001_initial.py
+++ b/tests/app/tests/migrations/elidable/0001_initial.py
@@ -15,7 +15,7 @@ class Migration(migrations.Migration):
             fields=[
                 (
                     "id",
-                    models.AutoField(
+                    models.BigAutoField(
                         auto_created=True,
                         primary_key=True,
                         serialize=False,

--- a/tests/app/tests/migrations/incorrect_name/initial.py
+++ b/tests/app/tests/migrations/incorrect_name/initial.py
@@ -15,7 +15,7 @@ class Migration(migrations.Migration):
             fields=[
                 (
                     "id",
-                    models.AutoField(
+                    models.BigAutoField(
                         auto_created=True,
                         primary_key=True,
                         serialize=False,

--- a/tests/app/tests/migrations/pg_indexes/0002_use_index.py
+++ b/tests/app/tests/migrations/pg_indexes/0002_use_index.py
@@ -17,7 +17,7 @@ class Migration(migrations.Migration):
             fields=[
                 (
                     "id",
-                    models.AutoField(
+                    models.BigAutoField(
                         auto_created=True,
                         primary_key=True,
                         serialize=False,

--- a/tests/app/tests/migrations/pg_indexes_custom/0002_use_index.py
+++ b/tests/app/tests/migrations/pg_indexes_custom/0002_use_index.py
@@ -17,7 +17,7 @@ class Migration(migrations.Migration):
             fields=[
                 (
                     "id",
-                    models.AutoField(
+                    models.BigAutoField(
                         auto_created=True,
                         primary_key=True,
                         serialize=False,

--- a/tests/app/tests/migrations/simple/0001_initial.py
+++ b/tests/app/tests/migrations/simple/0001_initial.py
@@ -15,7 +15,7 @@ class Migration(migrations.Migration):
             fields=[
                 (
                     "id",
-                    models.AutoField(
+                    models.BigAutoField(
                         auto_created=True,
                         primary_key=True,
                         serialize=False,

--- a/tests/app/tests/migrations/swappable_dependency/0001_initial.py
+++ b/tests/app/tests/migrations/swappable_dependency/0001_initial.py
@@ -16,7 +16,7 @@ class Migration(migrations.Migration):
             fields=[
                 (
                     "id",
-                    models.AutoField(
+                    models.BigAutoField(
                         auto_created=True,
                         primary_key=True,
                         serialize=False,

--- a/tests/app2/tests/migrations/foreign_key/0001_initial.py
+++ b/tests/app2/tests/migrations/foreign_key/0001_initial.py
@@ -17,7 +17,7 @@ class Migration(migrations.Migration):
             fields=[
                 (
                     "id",
-                    models.AutoField(
+                    models.BigAutoField(
                         auto_created=True,
                         primary_key=True,
                         serialize=False,

--- a/tests/app3/tests/migrations/moved/0001_initial.py
+++ b/tests/app3/tests/migrations/moved/0001_initial.py
@@ -15,7 +15,7 @@ class Migration(migrations.Migration):
             fields=[
                 (
                     "id",
-                    models.AutoField(
+                    models.BigAutoField(
                         auto_created=True,
                         primary_key=True,
                         serialize=False,

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -17,6 +17,8 @@ import os
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
+DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
+
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/2.0/howto/deployment/checklist/

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -87,7 +87,7 @@ def test_squashing_elidable_migration_simple(migration_app_dir, call_squash_migr
                 migrations.CreateModel(
                     name="Person",
                     fields=[
-                        ("id", models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                        ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
                         ("name", models.CharField(max_length=10)),
                         ("dob", models.DateField()),
                     ],
@@ -582,7 +582,7 @@ def test_swappable_dependency_migrations(migration_app_dir, settings, call_squas
                 migrations.CreateModel(
                     name="UserProfile",
                     fields=[
-                        ("id", models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                        ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
                         ("dob", models.DateField()),
                         ("user", models.ForeignKey(on_delete=models.CASCADE, to=settings.AUTH_USER_MODEL)),
                     ],
@@ -633,7 +633,7 @@ def test_squashing_migration_pg_indexes(migration_app_dir, call_squash_migration
                 migrations.CreateModel(
                     name="Message",
                     fields=[
-                        ("id", models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                        ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
                         ("score", models.IntegerField(default=0)),
                         ("unicode_name", models.CharField(db_index=True, max_length=255)),
                     ],
@@ -692,7 +692,7 @@ def test_squashing_migration_pg_indexes_custom(migration_app_dir, call_squash_mi
                 migrations.CreateModel(
                     name="Message",
                     fields=[
-                        ("id", models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                        ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
                         ("score", models.IntegerField(default=0)),
                         ("unicode_name", models.CharField(db_index=True, max_length=255)),
                     ],


### PR DESCRIPTION
New change in the `main` branch caused tests to fail because they're using `BigAutoField` instead of `AutoField`